### PR TITLE
[WIP] Send individual http request per alert

### DIFF
--- a/consul/client.go
+++ b/consul/client.go
@@ -250,8 +250,6 @@ func (c *ConsulAlertClient) LoadConfig() {
 				valErr = loadCustomValue(&config.Notifiers.HttpEndpoint.BaseURL, val, ConfigTypeString)
 			case "consul-alerts/config/notifiers/http-endpoint/endpoint":
 				valErr = loadCustomValue(&config.Notifiers.HttpEndpoint.Endpoint, val, ConfigTypeString)
-			case "consul-alerts/config/notifiers/http-endpoint/payload":
-				valErr = loadCustomValue(&config.Notifiers.HttpEndpoint.Payload, val, ConfigTypeStrMap)
 
 			// iLert notfier config
 			case "consul-alerts/config/notifiers/ilert/enabled":

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3'
+
+services:
+
+  consul-agent-1: &consul-agent
+    image: consul:latest
+    networks:
+      - consul-demo
+    command: "agent -retry-join consul-server-bootstrap -client 0.0.0.0"
+
+  consul-agent-2:
+    <<: *consul-agent
+
+  consul-agent-3:
+    <<: *consul-agent
+
+  consul-server-1: &consul-server
+    <<: *consul-agent
+    command: "agent -server -retry-join consul-server-bootstrap -client 0.0.0.0"
+
+  consul-server-2:
+    <<: *consul-server
+
+  consul-server-bootstrap:
+    <<: *consul-agent
+    ports:
+      - "8400:8400"
+      - "8500:8500"
+      - "8600:8600"
+      - "8600:8600/udp"
+    command: "agent -server -bootstrap-expect 3 -ui -client 0.0.0.0"
+
+networks:
+  consul-demo:


### PR DESCRIPTION
# WIP - This is only a work-in-progress

This PR changes the way alerts being sent to http endpoint. Previously it uses go template to render the payload based on data from consul. This method has a flaw that if the cluster is firing multiple alerts at once (for example multiple services down ), the rendered payload will contains data concatenated from multiple checks data. This is an example
```
  {
          "event": "criticalpassingpassingcritical",
          "node": "instance-1instance-2instance-2instance-4",
          "region": "data-center-1",
          "service": "serviceAserviceBserviceCserviceA"
  }
```
With this received payload, it's impossible to know what is happening. Instead, we will loop through the alert message, and send a http request for each alert. 